### PR TITLE
Improve setup of angular-translate

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -1,7 +1,8 @@
 var app = angular.module('HowToApp', ["ui.bootstrap", 'ngAnimate', 'ngCookies', 'pascalprecht.translate']);
  
 app.config(['$translateProvider', function ($translateProvider) {
-  $translateProvider.registerAvailableLanguageKeys(['en', 'de'], {
+  var supported_languages = ['en', 'de'];
+  $translateProvider.registerAvailableLanguageKeys(supported_languages, {
     'en_*': 'en',
     'de_*': 'de'
   })
@@ -10,8 +11,14 @@ app.config(['$translateProvider', function ($translateProvider) {
     suffix: '.json'
   });
   $translateProvider.determinePreferredLanguage();
+  // set preferred language to english in case an unsupported or invalid
+  // language was determined.
+  if (supported_languages.indexOf($translateProvider.preferredLanguage()) < 0) {
+    $translateProvider.preferredLanguage("en");
+  }
   $translateProvider.fallbackLanguage("en");
   $translateProvider.useLocalStorage();
+  $translateProvider.useSanitizeValueStrategy('sanitizeParameters');
 }]);
  
 app.controller('MainController', ['$translate', '$scope', function ($translate, $scope) {


### PR DESCRIPTION
The page fails to display in case no preferred language is configured in the user's browser. An exception is raised on the first call to translate: "No language key specified for loading". Also, if an unsupported language is configured (e.g. French), the page tries to load translations from a non-existing URL.

The root cause for both issues seems to be a bug in angular-translate, but it's easy to work around by checking the result of determinePreferredLanguage against the list of supported languages.
